### PR TITLE
Adding end_date to u-az513 namelist.

### DIFF
--- a/confs/rose-app-expanded.conf
+++ b/confs/rose-app-expanded.conf
@@ -194,6 +194,7 @@ ymin=
 
 [namelist:models(u-az513)]
 enabled=true
+end_date=2015-01-01
 label=UKESM1.0 historical #5
 laf_file=/scale_wlg_nobackup/filesets/nobackup/niwa00013/williamsjh/cylc-run/u-bc048/share/data/History_Data/bc048a.pm1960jan.pp
 laf_stashcode=m01s03i395


### PR DESCRIPTION
Adding `end_date` for u-az513. Must be present or software will always start from scratch with this model.